### PR TITLE
feat: create containers for neovim latest and stable

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.19.1
+
+WORKDIR /src
+
+RUN apk update
+
+RUN apk add build-base cmake coreutils curl unzip gettext-tiny-dev
+
+RUN apk add git
+
+RUN git clone https://github.com/neovim/neovim
+
+RUN cd neovim && make CMAKE_BUILD_TYPE=RelWithDebInfo
+
+RUN cd neovim && make install

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:jammy-20240227
+
+WORKDIR /src
+
+RUN apt update
+
+RUN apt-get install -y ninja-build gettext cmake unzip curl 
+
+RUN apt-get install -y git
+
+RUN git clone https://github.com/neovim/neovim
+
+RUN cd neovim && git checkout v0.9.5 && make CMAKE_BUILD_TYPE=RelWithDebInfo
+
+RUN cd neovim && make install


### PR DESCRIPTION
Alpine 3.19.1 with neovim latest
Ubuntu jammy-20240227 with neovim stable (0.9.5)

Use these containers as the base for development. Needs more tooling, such as more neovim setup and possibly some other tools like zsh in order to be initially complete.