### PR TITLE
chore: add linux distros and version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # neovim Development containers
+
+Contains Dockerfiles that can be used to set up various development containers for using neovim as the editor.
+
+## Containers
+
+### Alpine Linux and neovim
+
+Alpine 3.19.1
+
+neovim latest
+
+### Ubuntu Linux and neovim
+
+Ubuntu Jammy-20240227
+
+neovim stable v0.9.5


### PR DESCRIPTION
Alpine and Ubuntu, both with neovim.
Added this information to the readme including the version information for each.

Added a little about what the repo was for too.